### PR TITLE
Adjust teamleader url to focus.teamleader.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A ruby wrapper around Teamleader.eu API v1.
 
-**Please note that this gem is linked to the [deprecated Teamleader API](https://apidocs.teamleader.be/). Teamleader recommends to use the [new Teamleader API](https://developer.teamleader.eu/).**
+**Please note that this gem is linked to the [deprecated Teamleader API](https://apidocs.teamleader.be/). Teamleader recommends to use the [new Teamleader API](https://developer.focus.teamleader.eu/).**
 
 Some endpoints are still missing. Don't hesitate to open an issue or a PR if you need one of them.
 

--- a/lib/teamleader/api.rb
+++ b/lib/teamleader/api.rb
@@ -4,7 +4,7 @@ require 'net/http'
 require 'uri'
 
 module Teamleader
-  API_BASE_URL = "https://app.teamleader.eu/api"
+  API_BASE_URL = "https://focus.teamleader.eu/api"
 
   class Api
     include Teamleader::CustomFields


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.